### PR TITLE
Fix accordion transition, summary length

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -3,6 +3,7 @@ baseURL = "/"
 languageCode = "en-us"
 title = "Eviction Lab Sandbox"
 theme = "behave"
+summaryLength = 50
 
 [[menu.updates]]
     name = "Events"

--- a/src/sass/_index.scss
+++ b/src/sass/_index.scss
@@ -197,13 +197,15 @@
     }
   }
   .answer {
-    padding-bottom: 3rem;
-    @include for-phone-only {
-      padding-bottom: 2rem;
-    }
     @include defaultFont(20px);
     a {
       display: inline;
+    }
+    p {
+      padding-bottom: 3rem;
+      @include for-phone-only {
+        padding-bottom: 2rem;
+      }
     }
   }
 }


### PR DESCRIPTION
Updating the configuration for the summary length, and moving the padding to the `p` tag instead of the answer div so that the expand/collapse animation isn't as choppy. Gif example below (but the gif is a bit choppy so not sure you can fully tell)

![accordion](https://user-images.githubusercontent.com/8291663/36912712-3bac7b0a-1e0d-11e8-8a7b-403a669a32e0.gif)
