### PR TITLE
Add Travis deployment setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: node_js
+dist: trusty
+node_js:
+- '8'
+script:
+- npm run build
+before_deploy:
+- pip install --user awscli
+- export PATH=$PATH:$HOME/.local/bin
+deploy:
+- skip_cleanup: true
+  provider: s3
+  access_key_id: $AWS_ACCESS_KEY_ID
+  secret_access_key: $AWS_SECRET_ACCESS_KEY
+  bucket: eviction-lab-website-beta-staging
+  region: us-east-1
+  acl: public_read
+  local_dir: dist
+  on:
+    branch: cms-dev
+- skip_cleanup: true
+  provider: s3
+  access_key_id: $AWS_ACCESS_KEY_ID
+  secret_access_key: $AWS_SECRET_ACCESS_KEY
+  bucket: eviction-lab-website-beta
+  region: us-east-1
+  acl: public_read
+  local_dir: dist
+  on:
+    branch: master
+- provider: script
+  script: aws cloudfront create-invalidation --distribution-id=$CLOUDFRONT_ID --paths="/*"
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ deploy:
   provider: s3
   access_key_id: $AWS_ACCESS_KEY_ID
   secret_access_key: $AWS_SECRET_ACCESS_KEY
-  bucket: eviction-lab-website-beta-staging
+  bucket: eviction-lab-website-staging
   region: us-east-1
   acl: public_read
   local_dir: dist
@@ -26,7 +26,7 @@ deploy:
   provider: s3
   access_key_id: $AWS_ACCESS_KEY_ID
   secret_access_key: $AWS_SECRET_ACCESS_KEY
-  bucket: eviction-lab-website-beta
+  bucket: eviction-lab-website
   region: us-east-1
   acl: public_read
   local_dir: dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ deploy:
   local_dir: dist
   on:
     branch: cms-dev
+- provider: script
+  script: aws cloudfront create-invalidation --distribution-id=$CLOUDFRONT_ID_DEV --paths="/*"
+  on:
+    branch: cms-dev
 - skip_cleanup: true
   provider: s3
   access_key_id: $AWS_ACCESS_KEY_ID
@@ -29,6 +33,6 @@ deploy:
   on:
     branch: master
 - provider: script
-  script: aws cloudfront create-invalidation --distribution-id=$CLOUDFRONT_ID --paths="/*"
+  script: aws cloudfront create-invalidation --distribution-id=$CLOUDFRONT_ID_PROD --paths="/*"
   on:
     branch: master


### PR DESCRIPTION
Closes #2. Runs the build script for all branches, but only deploys `cms-dev` to staging and `master` to the main production bucket. Deploying to master also invalidates that CloudFront distribution's cache