### PR TITLE
Specify utf-8 charset in header

### DIFF
--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en-US">
 	<head>
-
+		<meta charset="utf-8" />
 		<!-- Google Tag Manager -->
 		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/site/themes/behave/layouts/partials/header.html
+++ b/site/themes/behave/layouts/partials/header.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en-US">
 	<head>
-
+		<meta charset="utf-8" />
 		<!-- Google Tag Manager -->
 		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
I was getting an error about this locally, so I added it to any heading template. Ignore any failing build that's using `rake`. It looks like it defaults to Ruby while the `.travis.yml` file isn't merged in