### PR TITLE
Add mobile-vh class to fix mobile vh transitions

### DIFF
--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -2,7 +2,7 @@
 
 <!-- ********** splash section ********** -->
 
-<div class="new-splash">
+<div class="new-splash mobile-vh">
   <div class="section section-split">
 
     <!-- ********* slider *********** -->
@@ -61,11 +61,11 @@
 
 <!-- ********** pictorial menu section ********** -->
 
-<div class="pictorial-wrapper" id="pictorial-anchor">
+<div class="pictorial-wrapper mobile-vh" id="pictorial-anchor">
 
-  <div class="top-row">
+  <div class="top-row mobile-vh">
 
-    <div class="left">
+    <div class="left mobile-vh">
       <a href="#">
         <h2 class="break-me">map &amp; data</h2>
         <p>Learn about the American housing crisis by interacting with a customizable map.</p>
@@ -74,7 +74,7 @@
       <div class="hover-bar-top-left"></div>
     </div>
 
-    <div class="right">
+    <div class="right mobile-vh">
       <a href="#">
         <h2>eviction rankings</h2>
         <p>Learn which cities rank the highest and lowest in evictions in the U.S.</p>
@@ -85,31 +85,31 @@
 
   </div>
   <!-- ******************** -->
-  <div class="middle-row">
+  <div class="middle-row mobile-vh">
 
-    <div class="left">
+    <div class="left mobile-vh">
       <a href="#">learn about the eviction lab</a>
       <div class="hover-bar-middle-left"></div>
     </div>
 
-    <div class="middle-left">
+    <div class="middle-left mobile-vh">
       <a href="#">learn about the problem</a>
       <div class="hover-bar-middle-middle-left"></div>
     </div>
 
-    <div class="middle-right">
+    <div class="middle-right mobile-vh">
       <a href="#">read about our methodology</a>
       <div class="hover-bar-middle-middle-right"></div>
     </div>
 
-    <div class="right">
+    <div class="right mobile-vh">
       <a href="#">get help and <br> read the faq</a>
       <div class="hover-bar-middle-right"></div>
     </div>
 
   </div>
   <!-- ******************** -->
-  <div class="bottom-row">
+  <div class="bottom-row mobile-vh">
 
     <div class="left">
       {{ $blog := where .Site.RegularPages "Params.childof" "blog" }}

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -53,5 +53,6 @@
 <script src="/js/main.js"></script>
 <script src="/js/smooth-scroll.js"></script>
 <script src="/js/social-share-popup.js"></script>
+<script src="/js/mobile-vh-fix.js"></script>
 </body>
 </html>

--- a/site/static/js/mobile-vh-fix.js
+++ b/site/static/js/mobile-vh-fix.js
@@ -1,0 +1,19 @@
+// On window resize, check if the width has changed, and if so unset transitions
+document.addEventListener("DOMContentLoaded", function (event) {
+  var width = window.innerWidth;
+  window.addEventListener("resize", function (e) {
+    // Only trigger transition if the width has changed, otherwise exit
+    if (window.innerWidth === width) { return; }
+    width = window.innerWidth;
+
+    document.querySelectorAll('.mobile-vh').forEach(function (el) {
+      el.style.transition = 'none';
+      el.style.height = el.offsetHeight + 'px';
+
+      setTimeout(function () {
+        el.style.height = null;
+        setTimeout(function () { el.style.transition = null; }); 
+      }, 350);
+    });
+  });
+});

--- a/site/themes/behave/layouts/index.html
+++ b/site/themes/behave/layouts/index.html
@@ -2,7 +2,7 @@
 
 <!-- ********** splash section ********** -->
 
-<div class="new-splash">
+<div class="new-splash mobile-vh">
   <div class="section section-split">
 
     <!-- ********* slider *********** -->
@@ -61,11 +61,11 @@
 
 <!-- ********** pictorial menu section ********** -->
 
-<div class="pictorial-wrapper" id="pictorial-anchor">
+<div class="pictorial-wrapper mobile-vh" id="pictorial-anchor">
 
-  <div class="top-row">
+  <div class="top-row mobile-vh">
 
-    <div class="left">
+    <div class="left mobile-vh">
       <a href="#">
         <h2 class="break-me">map &amp; data</h2>
         <p>Learn about the American housing crisis by interacting with a customizable map.</p>
@@ -74,7 +74,7 @@
       <div class="hover-bar-top-left"></div>
     </div>
 
-    <div class="right">
+    <div class="right mobile-vh">
       <a href="#">
         <h2>eviction rankings</h2>
         <p>Learn which cities rank the highest and lowest in evictions in the U.S.</p>
@@ -85,31 +85,31 @@
 
   </div>
   <!-- ******************** -->
-  <div class="middle-row">
+  <div class="middle-row mobile-vh">
 
-    <div class="left">
+    <div class="left mobile-vh">
       <a href="#">learn about the eviction lab</a>
       <div class="hover-bar-middle-left"></div>
     </div>
 
-    <div class="middle-left">
+    <div class="middle-left mobile-vh">
       <a href="#">learn about the problem</a>
       <div class="hover-bar-middle-middle-left"></div>
     </div>
 
-    <div class="middle-right">
+    <div class="middle-right mobile-vh">
       <a href="#">read about our methodology</a>
       <div class="hover-bar-middle-middle-right"></div>
     </div>
 
-    <div class="right">
+    <div class="right mobile-vh">
       <a href="#">get help and <br> read the faq</a>
       <div class="hover-bar-middle-right"></div>
     </div>
 
   </div>
   <!-- ******************** -->
-  <div class="bottom-row">
+  <div class="bottom-row mobile-vh">
 
     <div class="left">
       {{ $blog := where .Site.RegularPages "Params.childof" "blog" }}

--- a/src/sass/_utils.scss
+++ b/src/sass/_utils.scss
@@ -128,3 +128,7 @@
 .paddingtop3 {
   padding-top: $defaultPaddingWebsite;
 }
+
+.mobile-vh {
+  transition: $mobileVhTransition;
+}

--- a/src/sass/main-sass.scss
+++ b/src/sass/main-sass.scss
@@ -192,6 +192,10 @@ $outsetShadowTop: 0px -2px 8px 3px rgba(0, 0, 0, 0.24);
 $boxShadowBottom: 0px 2px 3px rgba( 0, 0, 0, 0.2 );
 $textShadow: 0px 2px 4px rgba( 0, 0, 0, 0.6 );
 
+// Mobile VH fix
+// ----
+$mobileVhTransition: height 3600s steps(1);
+
 // Gradients
 // ----
 @mixin gradient ($deg,$gradColor) {


### PR DESCRIPTION
Closes #91. In order to prevent weird scrolling behavior, you can just add the `mobile-vh` class to any element using `vh` and it will prevent resizing on mobile scroll. You can try it out here to see the difference https://fix-mobile-vh--eviction-lab.netlify.com/