### PR TITLE
Fix bootstrap dropdown smoothscroll

### DIFF
--- a/site/static/js/smooth-scroll.js
+++ b/site/static/js/smooth-scroll.js
@@ -45,7 +45,8 @@ $(function() {
           $('html,body').animate({
             scrollTop: target.offset().top - (getWindowOffset() + getPageOffset(location.pathname)) + 'px'
           }, 1000); // The number here represents the speed of the scroll in milliseconds
-          return false;
+          // Don't preventDefault in dropdowns
+          if (!$(this).hasClass('dropdown-item')) { return false; }
         }
       }
     });


### PR DESCRIPTION
Only returns false in smooth scroll function if the element does not have the class `dropdown-item` so that dropdowns still close after clicking