### PR TITLE
Add robots.txt disallowing all

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -5,6 +5,7 @@ title = "Eviction Lab Sandbox"
 theme = "behave"
 summaryLength = 50
 buildFuture = true
+enableRobotsTXT = true
 
 [[menu.main]]
     name = "Home"

--- a/site/layouts/robots.txt
+++ b/site/layouts/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Adds robots.txt file telling search engines not to index the site. It hasn't happened yet, so nothing to worry about, but we can just remove the "Disallow" line once we launch