### PR TITLE
Modal loops back to first record on end

### DIFF
--- a/site/layouts/partials/about-modal.html
+++ b/site/layouts/partials/about-modal.html
@@ -30,20 +30,32 @@
                     <h3>{{ .Params.title }}</h3>
                     <p class="bio-position">{{ .Params.position }}</p>
                     <div class="bio-content">{{ .Content }}</div>
-                  </div>  
+                  </div>
                   <div class="modal-footer">
-                      <div class="bio-nav prev">{{ if .NextInSection }} <a class="red" data-toggle="modal" data-target="#modal-{{ .NextInSection.Params.abbrev }}" data-dismiss="modal" href="#"><i class="fa fa-chevron-left">&nbsp;&nbsp;</i>Previous bio</a> {{ end }}</div>
-                      {{ if (.NextInSection ) (.PrevInSection) }}<div class="bio-nav red separator"> | </div>{{ end }}
-                      <div class="bio-nav next">{{ if .PrevInSection }} 
-                        <a class="red" data-toggle="modal" data-target="#modal-{{ .PrevInSection.Params.abbrev }}" data-dismiss="modal" href="#">Next bio&nbsp;&nbsp;<i class="fa fa-chevron-right"></i></a> 
-                        
-          <!-- Would like this conditional built so that when user reaches the end of the bios, the link below connects them to the first bio in the section -->
-                        
-                        {{ else }}
-                          <a class="red" data-toggle="modal" data-target="#modal-{{ .Params.abbrev }}" data-dismiss="modal" href="#">Next bio&nbsp;&nbsp;<i class="fa fa-chevron-right"></i></a>
-                        {{ end }}</div>
-
-          
+                      <div class="bio-nav prev">
+                        {{ if .NextInSection }}
+                        <a class="red" data-toggle="modal" data-target="#modal-{{ .NextInSection.Params.abbrev }}" data-dismiss="modal" href="#">
+                          <i class="fa fa-chevron-left">&nbsp;&nbsp;</i>Previous bio
+                        </a>
+                        {{ end }}
+                      </div>
+                      {{ $sectionPages := where .Site.RegularPages "Params.childof" .Params.childof }}
+                      {{ if and (.NextInSection) (or (.PrevInSection) (ge (len $sectionPages) 1)) }}
+                      <div class="bio-nav red separator"> | </div>
+                      {{ end }}
+                      <div class="bio-nav next">
+                        {{ if .PrevInSection }}
+                          <a class="red" data-toggle="modal" data-target="#modal-{{ .PrevInSection.Params.abbrev }}" data-dismiss="modal" href="#">
+                            Next bio&nbsp;&nbsp;<i class="fa fa-chevron-right"></i>
+                          </a>
+                        {{ else if ge (len $sectionPages) 1 }}
+                         {{ range first 1 $sectionPages }}
+                          <a class="red" data-toggle="modal" data-target="#modal-{{ .Params.abbrev }}" data-dismiss="modal" href="#">
+                            Next bio&nbsp;&nbsp;<i class="fa fa-chevron-right"></i>
+                          </a>
+                         {{ end }}
+                        {{ end }}
+                      </div>
                     <!--<button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>-->
                   </div>
                 </div>


### PR DESCRIPTION
Closes #111. The variable scoping for Hugo is a bit weird, so I repeated the creation of the Next button which is a little redundant, but this should work