### PR TITLE
Translate button implementation

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -12,10 +12,12 @@ enableRobotsTXT = true
 [Languages.en]
 weight = 0
 title = "Eviction Lab" 
+languageName = "English"
 
 [Languages.es]
 weight = 1
-title = "Eviction Lab" 
+title = "Eviction Lab"
+languageName = "Español"
 
 
 

--- a/site/layouts/partials/top.html
+++ b/site/layouts/partials/top.html
@@ -25,6 +25,18 @@
 							{{ end }}
 						</ul>
 					</nav>
+					{{ if .IsTranslated }}
+					<div class="dropdown language-select dropup">
+						<button class="el-select dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true">{{ .Language.LanguageName }} <i class="fa fa-chevron-down"></i></button>
+						<ul class="dropdown-menu">
+							{{ range .AllTranslations }}
+							<li class="dropdown menu-item">
+								<a href="{{ .Permalink }}">{{ .Language.LanguageName }}</a>
+							</li>
+							{{ end}}
+						</ul>
+					</div>
+					{{ end }}
 					<ul class="social-media-links">
 						<li>
 							<a tabindex="-1" class="btn btn-border" href="#" target="_blank">

--- a/site/layouts/partials/top.html
+++ b/site/layouts/partials/top.html
@@ -6,6 +6,20 @@
 					<img src="/img/eviction-lab-logo.svg" class="header-logo-img" alt="Eviction Lab Logo" />
 				</a>
 			</div>
+			 {{ if .IsTranslated }}
+			<div class="dropdown language-select">
+				<button class="el-select dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true">{{ .Language.LanguageName }}
+					<i class="fa fa-chevron-down"></i>
+				</button>
+				<ul class="dropdown-menu">
+					{{ range .AllTranslations }}
+					<li class="dropdown menu-item">
+						<a href="{{ .Permalink }}">{{ .Language.LanguageName }}</a>
+					</li>
+					{{ end}}
+				</ul>
+			</div>
+			{{ end }}
 			<div class="header-icons">
 				<button class="btn btn-icon el-button-menu">
 					<svg class="icon" id="menu" viewBox="0 0 22 22">

--- a/src/sass/_menu.scss
+++ b/src/sass/_menu.scss
@@ -100,21 +100,20 @@ $menuMargin: grid(5);
 }
 
 
-// Language Toggle - Only visible on "maps" mobile view
-// ---
-.app-menu .language-select.dropdown {
+.language-select.dropdown {
   display: block;
-  position:absolute;
-  width: grid(27);
-  left: $menuMargin;
-  bottom: grid(15);
-  background: none;
-  border: 4px solid #383d65;
+  margin: 0 grid(3) 0 grid(2);
+  height: grid(7);
+  width: grid(14);
+  -ms-flex-order: 3;
+  order: 3;
+  transition: all .4s ease; 
   border-radius: 0;
   box-shadow: none;
-  height: 40px;
+  color: #050403;
 
   .dropdown-menu {
+    text-align: left;
     top: auto;
     margin-bottom: 2px;
     position: absolute;
@@ -131,8 +130,8 @@ $menuMargin: grid(5);
     margin-top: 1px;
     width: 100%;
     box-sizing: border-box;
-    min-width: 80px;
-    max-height: 224px;
+    min-width: grid(10);
+    max-height: grid(28);
     padding: 0;
     overflow: auto;
     -webkit-overflow-scrolling: touch;
@@ -146,9 +145,9 @@ $menuMargin: grid(5);
         display: block;
         clear: both;
         font-weight: 400;
-        padding: 16px;
+        padding: grid(2);
         border-top: 1px solid #efefef;
-        min-height: 48px;
+        min-height: grid(6);
         white-space: normal;
         box-sizing: border-box;
         color: #050403;
@@ -161,25 +160,26 @@ $menuMargin: grid(5);
   }
 
   .el-select.dropdown-toggle {
-    padding: 8px 20px 8px 8px;
+    border: 1px solid #efefef;
+    padding: grid(1) grid(3) grid(1) grid(2);
     width: 100%;
     height: 100%;
-    color: #fff;
-    font-family: GT-Eesti-Display-Bold, sans-serif;
+    font-family: Akkurat-Regular,sans-serif;
     font-size: 13px;
     font-weight: 400;
     letter-spacing: .325px;
-    text-transform: uppercase;
     letter-spacing: .73125px;
     text-align: left;
     cursor: pointer;
+    color: #050403;
+    font-size: 14px;
 
     &::after { display: none; }
     .fa {
-      font-size: 8px;
-      right: 8px;
-      width: 8px;
-      height: 8px;
+      font-size: 14px;
+      right: grid(2);
+      width: 14px;
+      height: 14px;
       position: absolute;
       top: 50%;
       transform: translateY(-50%);
@@ -188,6 +188,62 @@ $menuMargin: grid(5);
   }
 }
 
+.header-content > .language-select.dropdown {
+  display: none;
+}
+@media(min-width: $gtMobile) {
+  .header-content > .language-select.dropdown {
+    display: block;
+  }
+}
+
+// scale language select
+@media(min-width: $gtTablet) {
+  .condensed {
+    .language-select.dropdown {
+      transform: scale(0.775);
+    }
+  }
+}
+
+// Language Toggle - Only visible on "maps" mobile view
+// ---
+.app-menu .language-select.dropdown {
+  position:absolute;
+  width: grid(27);
+  margin: 0;
+  left: $menuMargin;
+  bottom: grid(15);
+  background: none;
+  border: grid(0.5) solid #383d65;
+  height: grid(5);
+  font-family: GT-Eesti-Display-Bold, sans-serif;
+
+  .dropdown-menu {
+    padding: 0;
+    margin-bottom: 2px;
+  }
+  .el-select.dropdown-toggle {
+    padding: 8px 24px 8px 16px;
+    text-transform: uppercase;
+    border: none;
+    color: #fff;
+    font-size: 13px;
+
+    .fa {
+      font-size: grid(1);
+      height: grid(1);
+      right: grid(1);
+      width: grid(1);
+    }
+  }
+}
+
+@media(min-width: $gtTablet) {
+  .app-menu .language-select.dropdown {
+    display: none;
+  }
+}
 
 // Social media links
 // ---

--- a/src/sass/_menu.scss
+++ b/src/sass/_menu.scss
@@ -102,23 +102,89 @@ $menuMargin: grid(5);
 
 // Language Toggle - Only visible on "maps" mobile view
 // ---
-.app-menu .language-select { display: none; }
-.map-tool .app-menu .language-select {
+.app-menu .language-select.dropdown {
   display: block;
   position:absolute;
   width: grid(27);
   left: $menuMargin;
   bottom: grid(15);
-  .el-select .dropdown-toggle.btn {
-    background: none!important;
-    color: $white!important;
-    border: 4px solid $white;
-    border-radius: 2px;
+  background: none;
+  border: 4px solid #383d65;
+  border-radius: 0;
+  box-shadow: none;
+  height: 40px;
+
+  .dropdown-menu {
+    top: auto;
+    margin-bottom: 2px;
+    position: absolute;
+    left: 0;
+    z-index: 1000;
+    float: left;
+    font-size: 14px;
+    text-align: left;
+    list-style: none;
+    background-color: #fff;
+    background-clip: padding-box;
+    border-radius: 0;
+    border: none;
+    margin-top: 1px;
+    width: 100%;
+    box-sizing: border-box;
+    min-width: 80px;
+    max-height: 224px;
+    padding: 0;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    box-shadow: 0 3px 6px 0 hsla(0,0%,57%,.23);
+
+    li {
+      cursor: pointer;
+      a {
+        font-family: Akkurat-Regular,sans-serif;
+        width: 100%;
+        display: block;
+        clear: both;
+        font-weight: 400;
+        padding: 16px;
+        border-top: 1px solid #efefef;
+        min-height: 48px;
+        white-space: normal;
+        box-sizing: border-box;
+        color: #050403;
+        text-decoration: none;
+
+        &:hover { background-color: #efefef; }
+        &:focus { box-shadow: 0 0 5px 1px #e24000; }
+      }
+    }
   }
-}
-@media(min-width: $gtMobile) {
-  .map-tool .app-menu .language-select {
-    display: none;
+
+  .el-select.dropdown-toggle {
+    padding: 8px 20px 8px 8px;
+    width: 100%;
+    height: 100%;
+    color: #fff;
+    font-family: GT-Eesti-Display-Bold, sans-serif;
+    font-size: 13px;
+    font-weight: 400;
+    letter-spacing: .325px;
+    text-transform: uppercase;
+    letter-spacing: .73125px;
+    text-align: left;
+    cursor: pointer;
+
+    &::after { display: none; }
+    .fa {
+      font-size: 8px;
+      right: 8px;
+      width: 8px;
+      height: 8px;
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      color: #e24000;
+    }
   }
 }
 


### PR DESCRIPTION
Closes #119. Initial implementation of translate button. The CSS could probably be cleaned up, but creates a toggle with links to the English and Spanish version of the current page.

![language-toggle](https://user-images.githubusercontent.com/8291663/38174109-06ed8c9a-358e-11e8-9e21-d74e14ee777c.gif)
