### PR TITLE
Adjust footer nav breakpoint

### DIFF
--- a/src/sass/_footer.scss
+++ b/src/sass/_footer.scss
@@ -241,7 +241,7 @@ footer {
     }
   }
 }
-@media(min-width: $gtTablet) {
+@media(min-width: $gtSmallDesktop) {
   .footer-navigation {
     ul {
       font-size: 14px;


### PR DESCRIPTION
This should fix the horizontal overflow. The footer link columns were too wide for the screen size, so I increased the breakpoint