### PR TITLE
Add webkit prefix to sticky

### DIFF
--- a/src/sass/_buttons.scss
+++ b/src/sass/_buttons.scss
@@ -101,6 +101,7 @@
   height: 176px;
   width: 72px;
   position: sticky;
+  position: -webkit-sticky;
   top: 160px;
   background: #F4F7F9;
   text-align: center;


### PR DESCRIPTION
It looks like iOS needs the `-webkit-sticky` property to work, but this fixes it for the devices I'm looking at on BrowserStack