### PR TITLE
Adds placeholder 404 page

### DIFF
--- a/site/layouts/404.html
+++ b/site/layouts/404.html
@@ -1,0 +1,9 @@
+{{ partial "header" . }}
+<div class="center-page-wrapper page-404">
+    <div class="list-item center-content">
+        <div class="postlist-right-col">
+            <h2 class="title">Sorry, the page you were looking for was not found.</h2>
+        </div>
+    </div>
+</div>
+{{ partial "footer" . }}

--- a/src/sass/_index.scss
+++ b/src/sass/_index.scss
@@ -358,4 +358,6 @@ ul.anchor-links.dropdown-menu.show {
   border-bottom: none;
 }
 
-
+.page-404 {
+  height: 500px;
+}


### PR DESCRIPTION
Closes #94. Adds really basic 404 page just so we prevent raw error messages from displaying

<img width="789" alt="screen shot 2018-04-03 at 4 22 32 pm" src="https://user-images.githubusercontent.com/8291663/38276712-8b54ecd4-375b-11e8-9d26-1946fb1a6dc5.png">
