### PR TITLE
Sets up conditional for footer photo credit

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -4,4 +4,5 @@ date: 2017-11-19T20:43:49-08:00
 type: index
 hero: We're unpacking America's eviction crisis.
 heroP: The Eviction Lab at Princeton University has built the first nationwide database of evictions. Find out how many evictions happen in your community. Create custom maps, charts, and reports. Share facts with your neighbors and elected officials. 
+photoCredit: Testing Name
 ---

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -90,7 +90,9 @@
         </p>
       </div>
       <div class="footer-credits">
-        <p>Header photo by John Appleseed</p>
+        {{ if .Params.photoCredit }}
+        <p>Header photo by {{ .Params.photoCredit }}</p>
+        {{ end }}
       </div>
     </div>
   </footer>


### PR DESCRIPTION
Closes #148. We just need to add `photoCredit` to any page that needs attribution, otherwise it doesn't display

<img width="553" alt="screen shot 2018-04-05 at 11 55 27 am" src="https://user-images.githubusercontent.com/8291663/38380070-42363ae4-38c8-11e8-9dd3-e04d795bf68b.png">
