### PR TITLE
Add initial get data form

### DIFF
--- a/site/content/get-the-data/_index.es.md
+++ b/site/content/get-the-data/_index.es.md
@@ -1,0 +1,12 @@
+---
+title: "Get the Data | Eviction Lab"
+date: 2017-11-19T20:43:49-08:00
+type: index
+pagename: getthedata
+childof: getthedata
+introTitle: Get the Data
+intro: Enter your email to access the data and join our email list for notifications when there are data updates.
+emailLabel: Email
+newsletterLabel: Subscribe to our newsletter
+submitLabel: Get Data
+---

--- a/site/content/get-the-data/_index.md
+++ b/site/content/get-the-data/_index.md
@@ -1,0 +1,12 @@
+---
+title: "Get the Data | Eviction Lab"
+date: 2017-11-19T20:43:49-08:00
+type: index
+pagename: getthedata
+childof: getthedata
+introTitle: Get the Data
+intro: Enter your email to access the data and join our email list for notifications when there are data updates.
+emailLabel: Email
+newsletterLabel: Subscribe to our newsletter
+submitLabel: Get Data
+---

--- a/site/layouts/get-the-data/list.html
+++ b/site/layouts/get-the-data/list.html
@@ -1,0 +1,31 @@
+{{ partial "header" . }}
+
+<div class="data-form">
+    <div class="alt-bg"> 
+        <div class="center-content-post page-list text-li">
+            <h1>{{ .Params.introTitle }}</h1>
+            <p>{{ .Params.intro }}</p>
+            <form action="https://evrdhdxdjb.execute-api.us-east-1.amazonaws.com/prod/" method="post" name="get-the-data" class="validate" target="_blank">
+                <div>
+                    <div class="mc-field-group">
+                        <label for="email-field" class="sr-only">{{ .Params.email }}</label>
+                        <input id="email-field" class="form-control" type="email" value="" name="email" placeholder="{{ .Params.email }}">
+                    </div>
+                    <div class="mc-field-group input-group">
+                        <input type="checkbox" value="1" name="newsletter" id="newsletter-check">
+                        <label class="form-check-label" for="newsletter-check">{{ .Params.newsletterLabel }}</label>
+                    </div>
+                    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                    <div style="position: absolute; left: -5000px;" aria-hidden="true">
+                        <input type="text" name="b_8e16f46a586eeb4578fbfe6ba_9c55c12d21" tabindex="-1" value="">
+                    </div>
+                    <div class="form-footer">
+                        <input type="submit" value="{{ .Params.submitLabel }}" name="subscribe" id="mc-embedded-subscribe" class="btn btn-primary">
+                    </div>
+                </div>
+            </form>
+        </div>  
+    </div>
+</div>
+
+{{ partial "footer" . }}

--- a/site/layouts/get-the-data/list.html
+++ b/site/layouts/get-the-data/list.html
@@ -9,7 +9,7 @@
                 <div>
                     <div class="mc-field-group">
                         <label for="email-field" class="sr-only">{{ .Params.email }}</label>
-                        <input id="email-field" class="form-control" type="email" value="" name="email" placeholder="{{ .Params.email }}">
+                        <input id="email-field" class="form-control" type="email" value="" name="email" required placeholder="{{ .Params.email }}">
                     </div>
                     <div class="mc-field-group input-group">
                         <input type="checkbox" value="1" name="newsletter" id="newsletter-check">

--- a/src/sass/_data-form.scss
+++ b/src/sass/_data-form.scss
@@ -1,0 +1,15 @@
+.data-form .alt-bg {
+  padding-bottom: grid(10);
+
+  .center-content-post h1 {
+    font-family: $headerFontStack;
+    color: $color1;
+    text-align: center;
+    margin-bottom: 4rem;
+    text-transform: uppercase;
+  }
+}
+
+.form-footer {
+  margin-top: 3rem;
+}

--- a/src/sass/_data-form.scss
+++ b/src/sass/_data-form.scss
@@ -2,7 +2,7 @@
   padding-bottom: grid(10);
 
   .center-content-post h1 {
-    font-family: $headerFontStack;
+    font-family: $altFontStack;
     color: $color1;
     text-align: center;
     margin-bottom: 4rem;

--- a/src/sass/_inputs.scss
+++ b/src/sass/_inputs.scss
@@ -101,3 +101,7 @@ input[type=checkbox] {
     font-size: $inputFontSize_lg;
   }
 }
+
+.form-check-label {
+  @include defaultFont(15px);
+}

--- a/src/sass/main-sass.scss
+++ b/src/sass/main-sass.scss
@@ -466,4 +466,4 @@ p {
 @import 'eviction-matters';
 @import 'footer';
 @import 'contact';
-
+@import 'data-form';


### PR DESCRIPTION
Closes #134. Adds bare-bones Get the Data form with a working endpoint. Currently redirects to the preview site. The newsletter checkbox is functional, and it uses native browser functionality for requiring and validating the email

<img width="1273" alt="screen shot 2018-04-05 at 3 09 40 pm" src="https://user-images.githubusercontent.com/8291663/38389373-df4190b6-38e3-11e8-87de-69135f93d3c0.png">
