### PR TITLE
Update layout on bio images

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -34,7 +34,7 @@ gulp.task("sass", function() {
 // Compile CSS with PostCSS
 gulp.task("css", () => (
   gulp.src("./src/css/*.css")
-    .pipe(postcss([cssImport({from: "./src/css/main.css"}), cssnext()]))
+    .pipe(postcss([cssImport({from: "./src/css/main.css"}), cssnext({ browserslist: [ ">= 1% in US" ]})]))
     .pipe(gulp.dest("./dist/css"))
     .pipe(browserSync.stream())
 ));

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "whatwg-fetch": "^1.0.0"
   },
   "devDependencies": {
+    "autoprefixer": "^8.2.0",
     "gulp": "^3.9.1"
   }
 }

--- a/src/sass/_about-us.scss
+++ b/src/sass/_about-us.scss
@@ -224,7 +224,7 @@
  .bio-thumbs {
     display: flex;
     flex-wrap: wrap;
-    justify-content: flex-start;
+    justify-content: center;
     padding-bottom: 3.2rem;
     @include for-tablet-portrait-up {
         padding-bottom: 1.6rem;

--- a/src/sass/_about-us.scss
+++ b/src/sass/_about-us.scss
@@ -137,7 +137,15 @@
     }
 }
 .el-bios {
-    
+    // give bio images some breathing room
+    @include for-480-up {
+        margin-left: -16px;
+        margin-right: -16px;
+    }
+    @include for-tablet-portrait-up {
+        margin-left: -66px;
+        margin-right: -66px;
+    }
     ul.nav {
         a:hover {
             color: $color1;
@@ -216,41 +224,13 @@
  .bio-thumbs {
     display: flex;
     flex-wrap: wrap;
-    justify-content: space-evenly;
-    display: grid;
-    grid-template-columns: 1fr; 
+    justify-content: flex-start;
     padding-bottom: 3.2rem;
-    @include for-480-up {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-evenly;
-        display: -webkit-flex;
-        -webkit-flex-wrap: wrap;
-        -webkit-justify-content: space-evenly;
-        display: grid;
-        grid-template-columns: 1fr 1fr; 
-    }
     @include for-tablet-portrait-up {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-evenly;
-        display: -webkit-flex;
-        -webkit-flex-wrap: wrap;
-        -webkit-justify-content: space-evenly;
-        display: grid;
-        grid-template-columns: 1fr 1fr 1fr; 
         padding-bottom: 1.6rem;
     }
     @include for-tablet-landscape-up {
         padding: 32px;
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-evenly;
-        display: -webkit-flex;
-        -webkit-flex-wrap: wrap;
-        -webkit-justify-content: space-evenly;
-        display: grid;
-        grid-template-columns: 1fr 1fr 1fr 1fr; 
     }
     @include for-midsize-desktop-up {
         padding: 40px;
@@ -265,6 +245,16 @@
     }
     .bio-thumb-wrapper {
         position: relative;
+        width: 100%;
+        @include for-480-up {
+            width: 50%;
+        }
+        @include for-tablet-portrait-up {
+            width: 33.333%;
+        }
+        @include for-tablet-landscape-up {
+            width: 25%;
+        }
         a {
             text-decoration: none;
             display: flex;


### PR DESCRIPTION
Uses flexbox for bio instead of grid so it displays proper in IE11 (Closes #170 ).  

Updates the gulp build to autoprefix for any browsers with 1% or more usage in the US. (Fixes #163)