### PR TITLE
Fix spacing on IE11 subnav

### DIFF
--- a/src/sass/_subnav.scss
+++ b/src/sass/_subnav.scss
@@ -71,7 +71,7 @@
   padding: 25px 0;
   margin-bottom: 60px;
   display: flex;
-  justify-content: space-evenly;
+  justify-content: space-around;
   @include for-phone-only {
     justify-content: space-between;
   }


### PR DESCRIPTION
  - Sets `justify-content` to `space-around` instead of `space-evenly` for IE11 support

Before:
![image](https://user-images.githubusercontent.com/21034/38402798-26ccbb26-391c-11e8-9845-5d68b97d9722.png)


After:
![image](https://user-images.githubusercontent.com/21034/38402807-4413a8d4-391c-11e8-8432-d165a16a32f1.png)

