### PR TITLE
Re-add focus states

### DIFF
--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -43,8 +43,8 @@
       <a class="btn smoothScroll " href="#pictorial-anchor">{{ i18n "cta" }}</a>
 
       <div class="hero-social">
-          <a href="https://www.facebook.com/evictionlab/"><i class="fa fa-facebook"></i></a>
-          <a href="https://twitter.com/evictionlab"><i class="fa fa-twitter"></i></a>
+          <a href="https://www.facebook.com/evictionlab/" aria-label="Eviction Lab on Facebook"><i class="fa fa-facebook"></i></a>
+          <a href="https://twitter.com/evictionlab" aria-label="Eviction Lab on Twitter"><i class="fa fa-twitter"></i></a>
       </div>
 
       </div>

--- a/src/sass/_footer.scss
+++ b/src/sass/_footer.scss
@@ -101,7 +101,7 @@ footer {
   color: $white;
   a {
     color: $white;
-    &:hover { color: $color1; text-decoration: none; }
+    &:hover, &:focus { color: $color1; text-decoration: none; box-shadow:none; outline:0; }
   }
   p { @include defaultFont(10px); }
 }

--- a/src/sass/_home-pictorial-menu.scss
+++ b/src/sass/_home-pictorial-menu.scss
@@ -18,6 +18,13 @@
     display: block;
   }
 
+  .tr-block, .mr-block, .br-block {
+    @include full-shadow-animate;
+    &:hover .hover-bar { visibility: visible; }
+    a:focus .hover-bar { visibility: visible; }
+    a:focus { outline: 0; box-shadow: none; }
+  }
+
   /* -------------TOP ROW------------- */
   .top-row {
     position: relative;
@@ -40,10 +47,7 @@
     position: relative;
     width: 100%;
     height: 104px;
-    > a:focus { @include focusStateInset(); }
     @include hoverBar('hover-bar',50px,5px,20px,auto);
-    &:hover .hover-bar { visibility: visible; }
-    @include full-shadow-animate;
     @include for-414-up {
       flex-direction: row;
       width:50%;
@@ -199,12 +203,6 @@
     @include for-midsize-desktop-up {
       min-height: 248px;
     }
-    @include full-shadow-animate;
-    &:hover .hover-bar { visibility: visible; }
-    a:focus {
-      box-shadow: none;
-      .menu-wrapper { @include focusStateInset(); }
-    }
     &.left {
       background: #E04119;
       background: linear-gradient(to left, #952800 2%, #9F2D00 99%);
@@ -304,7 +302,6 @@
     flex-direction: column;
     justify-content: center;
     height:74px;
-    @include full-shadow-animate;
     background: #3c3c3c;
     @include hoverBar('hover-bar',50px,5px,8px,0);
     &:hover .hover-bar { visibility: visible; }

--- a/src/sass/_index.scss
+++ b/src/sass/_index.scss
@@ -323,6 +323,7 @@ ul.anchor-links.dropdown-menu.show {
     }
     &:focus {
       box-shadow: none;
+      outline:0;
       span {
         border: $focusBorder;
         // offset margins to keep in place

--- a/src/sass/_subnav.scss
+++ b/src/sass/_subnav.scss
@@ -54,7 +54,6 @@
   /* margin-right: 56px; */
   color: $textColor2;
   text-decoration: none;
-  padding-bottom: 22px;
   @include for-phone-only {
     margin-right: 14px;
   }

--- a/src/sass/main-sass.scss
+++ b/src/sass/main-sass.scss
@@ -398,9 +398,9 @@ $mobileVhTransition: height 3600s steps(1);
 
 // TODO: Re-add alternate state
 @mixin focusState() {
-  // outline: 0;
-  // box-shadow: 0 0 5px 1px $color1;
-  // border-color: $color1;
+  outline: 0;
+  box-shadow: 0 0 5px 1px $color1;
+  border-color: $color1;
 }
 
 @mixin focusStateInset() {
@@ -429,7 +429,7 @@ $mobileVhTransition: height 3600s steps(1);
 
 
 
-a:focus { @include focusState(); }
+a:focus, input:focus, textarea:focus, select:focus { outline-color: $color1; }
 /*
 p {
   font-size: 2.1rem;


### PR DESCRIPTION
- Re-add focus states for accessibility, use default browser focus state but overrides color (progress on #139 )
- Set custom focus states for items in pictorial menu
- Add missing `aria-labels` on homepage social media links (closes #177 )