### PR TITLE
Fix book buttons

### DIFF
--- a/src/sass/_eviction-matters.scss
+++ b/src/sass/_eviction-matters.scss
@@ -417,10 +417,23 @@
         justify-content: center;
 
         a.btn-primary {
-            height: 4.2rem;
-            padding: 1rem;
-            width: 16rem;
-            margin: 1rem;
+            width: grid(25);
+            margin: 0.5rem;
+            height: grid(7);
+            padding: grid(1);
+            box-sizing: border-box;
+            background: #fff;
+            border: 5px solid #f4f7f9;
+            color: rgb(145, 145, 145);
+            text-decoration: none;
+            font-size: 16px;
+            letter-spacing: .9px;
+            line-height: grid(4);
+            border-radius: 0;
+
+            &:hover, &:active {
+                color: #050403;
+            }
         }
     }
 }


### PR DESCRIPTION
Updated to match styles from map repo. Some of the sizing is a little different to get things to fit, but the overall styles match

<img width="564" alt="screen shot 2018-04-06 at 11 48 48 am" src="https://user-images.githubusercontent.com/8291663/38433465-98277170-3990-11e8-9262-4c1f07b5962d.png">
