### PR TITLE
Allow crawlers on prod

### DIFF
--- a/site/layouts/robots.prod.txt
+++ b/site/layouts/robots.prod.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow: /
+Disallow:


### PR DESCRIPTION
Closes #106. We need this so that the site can be indexed by search engines, but only in production. Merging it into cms-dev won't make it live because `robots.prod.txt` is only used on the master branch, so it's fine to merge this now