### PR TITLE
Fix iPad double tap on pictorial menu 

### DIFF
--- a/src/sass/_home-pictorial-menu.scss
+++ b/src/sass/_home-pictorial-menu.scss
@@ -20,8 +20,8 @@
 
   .tr-block, .mr-block, .br-block {
     @include full-shadow-animate;
-    a:hover .hover-bar { visibility: visible; }
-    a:focus .hover-bar { visibility: visible; }
+    a:hover .hover-bar { opacity:1; }
+    a:focus .hover-bar { opacity:1; }
     a:focus { outline: 0; box-shadow: none; }
   }
 

--- a/src/sass/main-sass.scss
+++ b/src/sass/main-sass.scss
@@ -378,7 +378,6 @@ $mobileVhTransition: height 3600s steps(1);
 // ----
 @mixin hoverBar($className,$width,$height,$topAndBottomMargin,$leftAndRightMargin) {
   .#{$className} {
-    visibility: hidden;
     width: $width;
     height: $height;
     min-height: $height;
@@ -386,6 +385,7 @@ $mobileVhTransition: height 3600s steps(1);
     padding: 0;
     margin: $topAndBottomMargin $leftAndRightMargin;
     display: none;
+    opacity:0;
     @include for-iphone-8plus-portrait-only {
       display: none;
     }
@@ -394,7 +394,7 @@ $mobileVhTransition: height 3600s steps(1);
     }
   }
   a:hover + .#{$className} {
-    visibility: visible;
+    opacity:0;
   }
 }
 


### PR DESCRIPTION
This fix seems to work on iOS simulator, but you should check on your iPad to make sure it works there just in case.

Closes #214 