### PR TITLE
Add page-specific descriptions for search engines

### DIFF
--- a/site/content/about/_index.es.md
+++ b/site/content/about/_index.es.md
@@ -6,7 +6,8 @@ h1: About Eviction Lab
 childof: about
 photoCredit: Sally Ryan
 hasSubnav: true
-description: Hemos construido la primera base de datos nacional de desalojos. 
+description: Learn about our background, work, and team members.
+socialDescription: Hemos construido la primera base de datos nacional de desalojos. 
 fbImage: 'https://evictionlab.org/images/og/eviction-lab-about-us-fb.jpg'
 twImage: 'https://evictionlab.org/images/og/eviction-lab-about-us-tw.jpg'
 ---

--- a/site/content/about/_index.md
+++ b/site/content/about/_index.md
@@ -6,7 +6,8 @@ h1: About Eviction Lab
 childof: about
 photoCredit: Sally Ryan
 hasSubnav: true
-description: We’ve built the first nationwide database of evictions. 
+description: Learn about our background, work, and team members.
+socialDescription: We’ve built the first nationwide database of evictions.  
 fbImage: 'https://evictionlab.org/images/og/eviction-lab-about-us-fb.jpg'
 twImage: 'https://evictionlab.org/images/og/eviction-lab-about-us-tw.jpg'
 ---

--- a/site/content/contact/_index.es.md
+++ b/site/content/contact/_index.es.md
@@ -4,5 +4,7 @@ date: 2017-11-19T20:43:49-08:00
 type: index
 childof: contact
 photoCredit: Sasha Israel
+description: Contact the Eviction Lab.
+socialDescription: We’ve built the first nationwide database of evictions.
 ---
 Para ponerse en contacto, utilice el formulario a continuación.

--- a/site/content/contact/_index.md
+++ b/site/content/contact/_index.md
@@ -4,5 +4,7 @@ date: 2017-11-19T20:43:49-08:00
 type: index
 childof: contact
 photoCredit: Sasha Israel
+description: Contact the Eviction Lab.
+socialDescription: We’ve built the first nationwide database of evictions.  
 ---
 To get in touch, please select your reason for contacting us from the dropdown menu, then fill out the form below.

--- a/site/content/data-merge/_index.md
+++ b/site/content/data-merge/_index.md
@@ -5,7 +5,8 @@ type: index
 pagename: datamerge
 childof: datamerge
 photoCredit: Sally Ryan
-
+description: Apply to have your data merged with the Eviction Lab's records.
+socialDescription: We’ve built the first nationwide database of evictions.  
 ---
 
 

--- a/site/content/get-the-data/_index.es.md
+++ b/site/content/get-the-data/_index.es.md
@@ -9,4 +9,6 @@ intro: Enter your email to access the data and join our email list for notificat
 emailLabel: Email
 newsletterLabel: Subscribe to our newsletter
 submitLabel: Get Data
+socialDescription: We’ve built the first nationwide database of evictions.  
+description: Download the full Eviction Lab dataset.
 ---

--- a/site/content/get-the-data/_index.md
+++ b/site/content/get-the-data/_index.md
@@ -9,4 +9,6 @@ intro: Enter your email to access the data and join our email list for notificat
 emailLabel: Email
 newsletterLabel: Subscribe to our newsletter
 submitLabel: Get Data
+socialDescription: We’ve built the first nationwide database of evictions.  
+description: Download the full Eviction Lab dataset.
 ---

--- a/site/content/help-faq/_index.es.md
+++ b/site/content/help-faq/_index.es.md
@@ -5,5 +5,7 @@ type: index
 homepage: updates
 photoCredit: Michael Kienitz
 hasSubnav: true
+socialDescription: We’ve built the first nationwide database of evictions.  
+description: Get help and read Frequently Asked Questions about The Eviction Lab.
 ---
 

--- a/site/content/help-faq/_index.md
+++ b/site/content/help-faq/_index.md
@@ -5,5 +5,7 @@ type: index
 homepage: updates
 photoCredit: Michael Kienitz
 hasSubnav: true
+socialDescription: We’ve built the first nationwide database of evictions.  
+description: Get help and read Frequently Asked Questions about The Eviction Lab.
 ---
 

--- a/site/content/methods/_index.es.md
+++ b/site/content/methods/_index.es.md
@@ -4,5 +4,7 @@ date: 2017-11-19T20:43:49-08:00
 type: index
 photoCredit: Michael Kienitz
 hasSubnav: true
+socialDescription: We’ve built the first nationwide database of evictions.  
+description: Read our Methods FAQ and download our full Methodology Report.
 ---
 

--- a/site/content/methods/_index.md
+++ b/site/content/methods/_index.md
@@ -4,5 +4,7 @@ date: 2017-11-19T20:43:49-08:00
 type: index
 photoCredit: Michael Kienitz
 hasSubnav: true
+socialDescription: We’ve built the first nationwide database of evictions.  
+description: Read our Methods FAQ and download our full Methodology Report.
 ---
 

--- a/site/content/updates/_index.md
+++ b/site/content/updates/_index.md
@@ -5,4 +5,6 @@ type: index
 homepage: updates
 photoCredit: Michael Kienitz
 hasSubnav: true
+socialDescription: We’ve built the first nationwide database of evictions.  
+description: Get the latest updates from The Eviction Lab.
 ---

--- a/site/content/updates/blog/_index.md
+++ b/site/content/updates/blog/_index.md
@@ -3,5 +3,7 @@ title: "Blog"
 date: 2017-11-19T20:43:20-09:00
 type: index
 childof: blog
+socialDescription: We’ve built the first nationwide database of evictions.  
+description: Read blog posts from The Eviction Lab.
 ---
 

--- a/site/content/updates/events/_index.md
+++ b/site/content/updates/events/_index.md
@@ -3,6 +3,6 @@ title: "Events"
 date: 2017-11-19T20:43:49-08:00
 type: index
 childof: events
+socialDescription: We’ve built the first nationwide database of evictions.  
+description: Find upcoming Eviction Lab events near you.
 ---
-
-Events top level page ... stuff happens here!

--- a/site/content/updates/media/_index.md
+++ b/site/content/updates/media/_index.md
@@ -3,5 +3,7 @@ title: "Media"
 date: 2017-11-19T20:43:20-08:00
 type: index
 childof: media
+socialDescription: We’ve built the first nationwide database of evictions.  
+description: See news coverage of The Eviction Lab.
 ---
 

--- a/site/content/updates/research/_index.md
+++ b/site/content/updates/research/_index.md
@@ -3,6 +3,8 @@ title: "Research"
 date: "2017-11-19T20:43:02-08:00"
 type: index
 childof: research
+socialDescription: We’ve built the first nationwide database of evictions.  
+description: Get research Updates from the Eviction Lab.
 ---
 
 Research index page

--- a/site/content/updates/research/el-research/_index.md
+++ b/site/content/updates/research/el-research/_index.md
@@ -3,6 +3,8 @@ title: "Eviction Lab Research"
 date: "2017-11-19T20:43:02-08:00"
 type: index
 childof: research
+socialDescription: We’ve built the first nationwide database of evictions.  
+description: Read the latest research from the Eviction Lab.
 ---
 
 EL research index page

--- a/site/content/updates/research/outside-research/_index.md
+++ b/site/content/updates/research/outside-research/_index.md
@@ -3,6 +3,8 @@ title: "Outside Research"
 date: "2017-11-19T20:43:02-08:00"
 type: index
 childof: research
+socialDescription: We’ve built the first nationwide database of evictions.  
+description: Read reports from outside researchers using Eviction Lab data.
 ---
 
 Outside Research index page

--- a/site/content/why-eviction-matters/_index.es.md
+++ b/site/content/why-eviction-matters/_index.es.md
@@ -4,7 +4,8 @@ date: 2017-11-19T20:43:49-08:00
 type: index
 photoCredit: Sasha Israel
 hasSubnav: true
-description: Hemos construido la primera base de datos nacional de desalojos.
+socialDescription: Hemos construido la primera base de datos nacional de desalojos. 
+description: Learn about eviction, its effects, and why it matters.
 fbImage: 'https://evictionlab.org/images/og/eviction-lab-why-eviction-matters-fb.jpg'
 twImage: 'https://evictionlab.org/images/og/eviction-lab-why-eviction-matters-tw.jpg'
 ---

--- a/site/content/why-eviction-matters/_index.md
+++ b/site/content/why-eviction-matters/_index.md
@@ -4,7 +4,8 @@ date: 2017-11-19T20:43:49-08:00
 type: index
 photoCredit: Sasha Israel
 hasSubnav: true
-description: We’ve built the first nationwide database of evictions. Create custom maps, charts, and reports, and learn about eviction in your area. 
+socialDescription: We’ve built the first nationwide database of evictions.  
+description: Learn about eviction, its effects, and why it matters.
 fbImage: 'https://evictionlab.org/images/og/eviction-lab-why-eviction-matters-fb.jpg'
 twImage: 'https://evictionlab.org/images/og/eviction-lab-why-eviction-matters-tw.jpg'
 ---

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -25,6 +25,10 @@
 		{{ if .Params.twImage }}
 			{{ $.Scratch.Set "twImage" .Params.twImage }}
 		{{ end }}
+		{{ if .Params.socialDescription }}
+			{{ $.Scratch.Set "socialDescription" .Params.socialDescription }}
+		{{ end }}
+		
 
 		<!-- General metadata -->
 		<meta name="description" content="{{ $.Scratch.Get "description" }}" />
@@ -33,7 +37,7 @@
 		<meta property="og:locale" content="en_US" />
 		<meta property="og:type" content="website" />
 		<meta property="og:title" content="{{ .Title }}" />
-		<meta property="og:description" content="{{ $.Scratch.Get "description" }}" />
+		<meta property="og:description" content="{{ $.Scratch.Get "socialDescription" }}" />
 		<meta property="og:url" content="{{ .Permalink }}" />
 		<meta property="og:site_name" content="Eviction Lab" />
 		<meta property="og:image" content="{{ $.Scratch.Get "fbImage" }}" />
@@ -42,7 +46,7 @@
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:site" content="@EvictionLab" />
 		<meta name="twitter:title" content="{{ .Title }}" />
-		<meta name="twitter:description" content="{{ $.Scratch.Get "description" }}" />
+		<meta name="twitter:description" content="{{ $.Scratch.Get "socialDescription" }}" />
 		<meta name="twitter:image" content="{{ $.Scratch.Get "twImage" }}" />
 
 		<link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
In anticipation of search engines showing structured page links to our content, I think it's a good idea to add page-specific descriptions. However, I'd like to keep the current standardized language across social media.

Accordingly I've created a new parameter called `socialDescription` for Twitter and Facebook, and edited the the `description` parameter for each page to say more about them. 