### PR TITLE
URL encode values so Spanish links work

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -135,11 +135,11 @@ languageName = "Español"
 [[Languages.es.menu.main]]
     name = "Mapa y datos"
     weight = 2
-    url = "/map/#/2016?lang=es"
+    url = "/map/#/2016%3Flang%3Des"
 [[Languages.es.menu.main]]
     name = "Rankings de desalojos"
     weight = 3
-    url = "/rankings/#/evictions?lang=es"
+    url = "/rankings/#/evictions%3Flang%3Des"
 [[Languages.es.menu.main]]
     name = "Acerca de nosotros"
     weight = 4
@@ -168,11 +168,11 @@ languageName = "Español"
 [[Languages.es.menu.footer]]
     name = "Mapa y datos"
     weight = 2
-    url = "/map/#/2016?lang=es"
+    url = "/map/#/2016%3Flang%3Des"
 [[Languages.es.menu.footer]]
     name = "Rankings de desalojos"
     weight = 3
-    url = "/rankings/#/evictions?lang=es"
+    url = "/rankings/#/evictions%3Flang%3Des"
 [[Languages.es.menu.footer]]
     name = "Acerca de nosotros"
     weight = 4


### PR DESCRIPTION
  - Fixes link to the rankings page redirecting to the map if user is viewing in Spanish
  - Fixes link to map so it remains in Spanish if user is viewing in Spanish

Closes #228 