### PR TITLE
Mobile updates

### DIFF
--- a/site/layouts/updates/list.html
+++ b/site/layouts/updates/list.html
@@ -32,7 +32,7 @@
 {{ range .Paginator.Pages }}   
 <!--{{ if eq .Params.contenttype "updates" }}    -->
 
-        <div class="center-page-wrapper mt1rem">
+        <div class="center-page-wrapper mt1rem list-wrapper">
             <div class="list-item center-content {{ .Params.contenttype }}-list">
 
             <!--<div class="chevron">
@@ -130,7 +130,7 @@
       {{ $paginator := .Paginate (where .Site.Pages "Params.contentcat" "blog") 5 }}   
       {{ range .Paginator.Pages }} 
 
-        <div class="center-page-wrapper">
+        <div class="center-page-wrapper list-wrapper">
           <div class="list-item center-content {{ .Params.childof }}-list">
 
             <!--<div class="chevron">
@@ -162,11 +162,11 @@
   {{ end }} <!-- end Blog listings -->
   <!-- PAGINATION -->  
 </div>
-<div class="center-page-wrapper">
+<!--<div class="center-page-wrapper">
   <div class="custom-pagination">
     {{ partial "pagination" . }}
   </div> 
-</div>
+</div> -->
 
 {{ end }} <!-- end Blog page stuff -->
 
@@ -182,7 +182,7 @@
       {{ $paginator := .Paginate (where .Site.Pages "Params.contentcat" "media") 5 }}   
       {{ range .Paginator.Pages }}
       
-      <div class="center-page-wrapper">
+      <div class="center-page-wrapper list-wrapper">
           <div class="list-item center-content {{ .Params.childof }}-list">
 
           <!--<div class="chevron">
@@ -214,11 +214,11 @@
   {{ end }} <!-- end Media listings -->
    <!-- PAGINATION -->  
 </div>
-<div class="center-page-wrapper">
+<!--<div class="center-page-wrapper">
   <div class="custom-pagination">
     {{ partial "pagination" . }}
   </div> 
-</div>
+</div>-->
 
 {{ end }} <!-- end Media page stuff -->
 
@@ -236,7 +236,7 @@
       {{ range first 1 (where .Site.RegularPages "Params.researchtype" ( "elresearch" )) }}
         {{ if eq .Params.researchtype "elresearch" }}
         <div class="alt-rows dual-research">
-        <div class="center-page-wrapper">
+        <div class="center-page-wrapper list-wrapper">
             <div class="list-item center-content {{ .Params.childof }}-list">
 
             <!--<div class="chevron">
@@ -269,7 +269,7 @@
 
   {{ $outsideresearch := where .Site.RegularPages "Params.researchtype" "outside-research" }} <!-- count Outside Research articles -->
   {{ if isset $outsideresearch 0 }} <!-- if there are Outside Research articles, list them -->
-  <div class="center-page-wrapper">          
+  <div class="center-page-wrapper list-wrapper">          
     <div class="events-list-header bordered-header research-type outside-research">outside research <a class="see-all-events subhead-rt" href="/updates/research/outside-research">See all</a></div>
       {{ range first 1 (where .Site.RegularPages "Params.researchtype" ( "outside-research" )) }}
         {{ if eq .Params.researchtype "outside-research" }}
@@ -319,7 +319,7 @@
       {{ $paginator := .Paginate (where .Site.Pages "Params.researchtype" "elresearch") 5 }}   
       {{ range .Paginator.Pages }}
       
-      <div class="center-page-wrapper">
+      <div class="center-page-wrapper list-wrapper">
           <div class="list-item center-content {{ .Params.childof }}-list">
 
           <!--<div class="chevron">
@@ -351,11 +351,11 @@
   {{ end }} <!-- end EL Research listings -->
    <!-- PAGINATION -->  
 </div>
-<div class="center-page-wrapper">
+<!--<div class="center-page-wrapper">
   <div class="custom-pagination">
     {{ partial "pagination" . }}
   </div> 
-</div>
+</div>-->
 
 {{ end }} <!-- end EL Research page stuff -->
 
@@ -372,7 +372,7 @@
       {{ $paginator := .Paginate (where .Site.Pages "Params.researchtype" "outside-research") 5 }}   
       {{ range .Paginator.Pages }}
       
-      <div class="center-page-wrapper">
+      <div class="center-page-wrapper list-wrapper">
           <div class="list-item center-content {{ .Params.childof }}-list">
 
           <!--<div class="chevron">
@@ -404,11 +404,11 @@
   {{ end }} <!-- end Outside Research listings -->
    <!-- PAGINATION -->  
 </div>
-<div class="center-page-wrapper">
+<!--<div class="center-page-wrapper">
   <div class="custom-pagination">
     {{ partial "pagination" . }}
   </div> 
-</div>
+</div>-->
 
 {{ end }} <!-- end EL Research page stuff -->
 
@@ -420,7 +420,7 @@
   {{ if isset $events 0 }} <!-- if there are Events articles, list them -->
   {{ $paginator := .Paginate (where .Site.RegularPages.Reverse "Params.childof" "events") 5 }}   
   {{ range .Paginator.Pages }}
-      <div class="center-page-wrapper">
+      <div class="center-page-wrapper list-wrapper">
           <div class="list-item center-content {{ .Params.childof }}-list-main events-list list-head">
             <!--<div class="chevron">
             <i class="fa fa-chevron-right"></i>
@@ -459,11 +459,11 @@
      
     {{ end }}
   {{ end }} <!-- end Events listings -->
-  <div class="center-page-wrapper">
+  <!--<div class="center-page-wrapper">
       <div class="custom-pagination">
         {{ partial "pagination" . }}
       </div> 
-    </div>
+    </div>-->
 {{ end }} <!-- end Events page stuff -->
 </div>
 <!-- ************** -->

--- a/src/sass/_lists.scss
+++ b/src/sass/_lists.scss
@@ -16,6 +16,7 @@
 .blog-list .list-wrapper:last-child, 
 .media-list .list-wrapper:last-child,
 .research-list .list-wrapper:last-child,
+.dual-research .list-wrapper:last-child
  {
     padding-bottom: 2.4rem;
     @include for-tablet-portrait-up {

--- a/src/sass/_lists.scss
+++ b/src/sass/_lists.scss
@@ -2,6 +2,34 @@
 
 
 /* blog and media lists */
+
+.list-wrapper {
+  overflow: auto;
+  &.mt1rem {
+    @include for-below-414 {
+        margin-top: 0; 
+        padding-top: 1.6rem;
+        padding-bottom: 1.6rem;
+    }
+  }
+}
+.blog-list .list-wrapper:last-child, 
+.media-list .list-wrapper:last-child,
+.research-list .list-wrapper:last-child,
+ {
+    padding-bottom: 2.4rem;
+    @include for-tablet-portrait-up {
+      padding-bottom: 3.2rem;
+    }
+    @include for-tablet-landscape-up {
+      padding-bottom: 4rem;
+    }
+    @include for-midsize-desktop-up {
+      padding-bottom: 4.8rem;
+    }
+    
+}
+
 .alt-rows {
   &.blog-list, &.media-list, &.research-list {
     margin-top: 0.8rem;
@@ -135,7 +163,11 @@
   &.updates-list .title a {
     /* color: #333333; */
   }
-  @include for-phone-only {
+  @include for-below-414 {
+    display: block;
+    min-height: initial;
+  }
+  @include for-414-thru-767 {
     display: grid;
     display: -ms-grid;
     min-height: initial;
@@ -180,6 +212,11 @@
     flex-grow: 1;
     max-width: 200px;
     min-width: 200px;
+    @include for-below-414 {
+      display: block;
+      float: left;
+      width: 34%;
+    }
     @include for-phone-only {
       min-width: initial;
       padding-right: 32px;
@@ -200,9 +237,12 @@
       justify-content: space-between;
     }
     .authorname {
+      @include for-below-414 {
+        margin-bottom: 0.8rem;
+      }
       @include for-phone-only {
         @include defaultFontBold($fontSizeExtraSmall);
-        letter-spacing: 0.04rem;
+        letter-spacing: 0rem;
         flex-grow: 3;
       }
       @include for-tablet-portrait-and-landscape {
@@ -223,6 +263,9 @@
       }
     }
     .list-thumb-container {
+      @include for-below-414 {
+        margin-bottom: 0.8rem;
+      }
       @include for-tablet-portrait-up {
         flex-grow: 1;
       }
@@ -231,6 +274,9 @@
     .post-date {
       color: #919191;
       flex-grow: 4;
+      @include for-below-414 {
+        margin-bottom: 1.6rem;
+      }
       @include for-phone-only {
         @include defaultFont($fontSizeExtraSmall);
         letter-spacing: 0rem;
@@ -343,6 +389,7 @@
   .postlist-right-col {
     flex-grow: 10;
     /* padding-top: 22px;*/
+    
     @include for-phone-only {
       display: flex;
       flex-direction: column;
@@ -358,7 +405,11 @@
       }   
       }
     .title {
-      @include for-phone-only {
+      @include for-below-414 {
+        height: auto;
+        margin-bottom: 1.6rem;
+      }
+      @include for-414-thru-767 {
         height: 76px;  
       }
     }

--- a/src/sass/_updates.scss
+++ b/src/sass/_updates.scss
@@ -28,7 +28,7 @@ a.cat-link {
     }
 }
 .events-list-header.research-type.outside-research {
-    padding-top: 32px;
+   /* padding-top: 32px; */
 }
 .events-type {
     color: #768693;


### PR DESCRIPTION
-Change layout to display:block
- Remove space devoted to (non-active) pagination
(This part is a slight hack -- commented out pagination because it adds a bunch of empty space if not active. There is obviously a better solution than this -- even just in CSS -- but I have to log off in a sec and just want to get this in before I do. Can fix tomorrow.)
