### PR TITLE
Alt splash

### DIFF
--- a/src/sass/_home-splash.scss
+++ b/src/sass/_home-splash.scss
@@ -78,6 +78,9 @@ $heroWidth: 300px;
     top: 0;
     right: 0;
     width: calc(100% - (((100% - #{$maxWidth}) / 2) + (#{$heroWidth} + #{$heroMargin} * 2.3)));
+    @include med-desktop {
+      width: calc(100% - (((100% - #{$maxWidth}) / 2) + (#{$heroWidth} + #{$heroMargin} * 2.3 - 60px )));
+    }
     @include for-midsize-desktop-up {
       width: calc(100% - (((100% - #{$maxWidth}) / 2) + (240px + #{$heroMargin} * 2.3)));
     }

--- a/src/sass/main-sass.scss
+++ b/src/sass/main-sass.scss
@@ -88,9 +88,9 @@ $gtLaptop: 1439px; // greater than laptop device breakpoint
 @mixin sm-thru-med-desktop {
   @media (min-width: $gtTablet) and (max-width: $smDesktopLimit) { @content; }
 }
-// 1060-1439px 
+// 1160-1439px 
 @mixin med-desktop {
-  @media (min-width: 1060px) and (max-width: $smDesktopLimit) { @content; }
+  @media (min-width: 1160px) and (max-width: $smDesktopLimit) { @content; }
 }
 @mixin for-desktop-up {
   @media (min-width: $gtSmallDesktop) { @content; }

--- a/src/sass/main-sass.scss
+++ b/src/sass/main-sass.scss
@@ -88,6 +88,10 @@ $gtLaptop: 1439px; // greater than laptop device breakpoint
 @mixin sm-thru-med-desktop {
   @media (min-width: $gtTablet) and (max-width: $smDesktopLimit) { @content; }
 }
+// 1060-1439px 
+@mixin med-desktop {
+  @media (min-width: 1060px) and (max-width: $smDesktopLimit) { @content; }
+}
 @mixin for-desktop-up {
   @media (min-width: $gtSmallDesktop) { @content; }
 }


### PR DESCRIPTION
Made a new breakpoint to try to reduce the excessive white space on the splash page, between about 1160—1439px, by expanding the hero width a bit. Not sure I did it in the most intelligent way, given the complex math involved. Please advise if improvements can be made here @pjsier and @Lane 