### PR TITLE
CSS cache bust

### DIFF
--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -56,7 +56,7 @@
 
     <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/6135894/6199192/css/fonts.css">
 		<link rel="stylesheet" type="text/css" href="/css/lib.min.css"/>
-    <link rel="stylesheet" type="text/css" href="/css/main-sass.css" />
+    <link rel="stylesheet" type="text/css" href="/css/main-sass.css?{{ now.Unix }}" />
   </head>
 
   <body class="debug-grid-16x helvetica tracked {{ if .Params.hasSubnav }}page-subnav{{ end }}">


### PR DESCRIPTION
Basic cache busting by adding the build timestamp on the CSS file to ensure old asset is not served.