### PR TITLE
hugo upgrade (0.73)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,4 +58,4 @@ deploy:
 
 env:
   global:
-    - HUGO_RELEASE=0.69.2
+    - HUGO_RELEASE=0.73

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,12 @@
 [build]
   publish = "public"
   command = "hugo"
-  HUGO_VERSION = "0.69.2"
+  HUGO_VERSION = "0.73"
 
 [context.deploy-preview]
   command = "hugo -D"
-  HUGO_VERSION = "0.69.2"
+  HUGO_VERSION = "0.73"
 
 [context.branch-deploy]
   command = "hugo -D"
-  HUGO_VERSION = "0.69.2"
+  HUGO_VERSION = "0.73"

--- a/themes/evictionlab/layouts/partials/agnosticbreadcrumb.html
+++ b/themes/evictionlab/layouts/partials/agnosticbreadcrumb.html
@@ -3,12 +3,12 @@
     {{ define "breadcrumb" }}
       {{ with .Parent }}
         {{ template "breadcrumb" . }}
-        <a href="{{ .URL }}">{{ if .IsHome }}Home{{ else }}{{.Title}}{{ end }}</a> <i class="fa fa-chevron-right"></i>
+        <a href="{{ .Permalink }}">{{ if .IsHome }}Home{{ else }}{{.Title}}{{ end }}</a> <i class="fa fa-chevron-right"></i>
       {{ end }}
     {{ end }}
     {{ if not .IsHome }}
         {{ template "breadcrumb" . }}
-        {{if (eq .Params.type "covid-policy-rankings") and (eq .Params.layout "single")}}
+        {{if (and (eq .Params.type "covid-policy-rankings") (eq .Params.layout "single"))}}
           {{- .Params.state_title -}}
         {{ else }}
           {{- .Title -}}

--- a/themes/evictionlab/layouts/partials/footer.html
+++ b/themes/evictionlab/layouts/partials/footer.html
@@ -138,7 +138,11 @@
 <script src="/js/lib.min.js"></script>
 <script src="/js/main.js?{{ now.Unix }}"></script>
 
-{{ if in .File.Dir "eviction-tracking" }}
+{{ with .File }}
+  {{ $.Scratch.Set "dir" .Dir }}
+{{ end }}
+
+{{ if in ($.Scratch.Get "dir") "eviction-tracking" }}
   {{ $lib := resources.Get "eviction-tracking/lib.min.js" }}
   {{ $app := resources.Get "eviction-tracking/app.js" }}
   {{ $appmin := $app | resources.Minify}}
@@ -146,7 +150,7 @@
   <script src="{{ ($js | fingerprint).RelPermalink }}"></script>
 {{ end }}
 
-{{ if in .File.Dir "covid-policy-rankings" }}
+{{ if in ($.Scratch.Get "dir") "covid-policy-rankings" }}
   {{ partial "covid-policy-rankings" . }}
 {{ end }}
 </body>

--- a/themes/evictionlab/layouts/partials/header.html
+++ b/themes/evictionlab/layouts/partials/header.html
@@ -97,10 +97,12 @@
       <link rel="stylesheet" href="{{ ($style | minify | fingerprint).RelPermalink }}">
 		{{ end }}
 		
-		{{ if in .File.Dir "eviction-tracking" }}
-			{{ $reportcss := resources.Get "eviction-tracking/app.css" | resources.PostCSS }}
-			<link href='https://api.mapbox.com/mapbox-gl-js/v1.9.1/mapbox-gl.css' rel='stylesheet' />
-			<link rel="stylesheet" href="{{ ($reportcss | minify | fingerprint).RelPermalink }}" />
+		{{ with .File }}
+			{{ if in .Dir "eviction-tracking" }}
+				{{ $reportcss := resources.Get "eviction-tracking/app.css" | resources.PostCSS }}
+				<link href='https://api.mapbox.com/mapbox-gl-js/v1.9.1/mapbox-gl.css' rel='stylesheet' />
+				<link rel="stylesheet" href="{{ ($reportcss | minify | fingerprint).RelPermalink }}" />
+			{{ end }}
 		{{ end }}
 
   </head>


### PR DESCRIPTION
# Changes
- Change `.URL` to `.Permalink` to resolve warnings
- Change `.File.Dir` to `with .File` and store directory in scratch to resolve warning
- Update `and` call in `agnosticbreadcrumb` partial to fix build error
- Update netlify / travis config to use v0.73