### PR TITLE
Update styles for comparison bar section

### DIFF
--- a/themes/evictionlab/assets/eviction-tracking/app.css
+++ b/themes/evictionlab/assets/eviction-tracking/app.css
@@ -1807,6 +1807,10 @@
   text-align: start;
 }
 
+.section:nth-child(2n).section--chart.section--race .comparison-block-wrapper {
+  border: #f5f7f9 solid 3px;
+}
+
 @media (min-width: 600px) {
   .section--chart.section--race .comparison-block-wrapper {
     /* keep in sync with CHART_2_CONFIG/CHART_2A_CONFIG margin right/left */
@@ -2404,9 +2408,10 @@ label #labels_top-100 {
 .intro__content .footnote {
   font-size: 1.2rem;
   color: var(--text-secondary);
-  max-width: 320px;
   margin: auto;
+  max-width: 320px;
 }
+
 .section .footnote span,
 .section .additional-footnote span {
   display: block;

--- a/themes/evictionlab/layouts/shortcodes/report_chart.html
+++ b/themes/evictionlab/layouts/shortcodes/report_chart.html
@@ -61,6 +61,9 @@
         </div>
     </div>
     <div class="additional-footnote">
+      <div class="mt-2 mt-md-0">
+        <span class="data-download"><a href="{{ .Get `data` }}">Get the data</a> for these figures</span>
+      </div>
       <ul>
         <li>
           Statistics rely on imputation of race/ethnicity and gender based on defendant names and addresses. We refer to “gender”
@@ -69,8 +72,6 @@
           methods page</a>. ACS data are from 2015-2019 five-year estimates.
         </li>
       </ul>
-      <br />
-      <span class="data-download"><a href="{{ .Get `data` }}">Get the data</a> for these figures</span>
     </div>
   </div>
   <script>


### PR DESCRIPTION
- add grey border to comparison sections with white background (e.g. Albuquerque)
- move data download above footnotes to be consistent with other sections